### PR TITLE
Insert optional jpegtran switches before the file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,11 +22,11 @@ module.exports = opts => buf => {
 	];
 
 	if (opts.progressive) {
-		args.push('-progressive');
+		args.splice(0, 0, '-progressive');
 	}
 
 	if (opts.arithmetic) {
-		args.push('-arithmetic');
+		args.splice(0, 0, '-arithmetic');
 	}
 
 	return execBuffer({


### PR DESCRIPTION
Inserting parameters at the end of the args list causes jpegtran to throw `jpegtran: only one input file` error.

Maybe related to https://github.com/imagemin/imagemin-jpegtran/issues/7?

Details of the jpegtran error below
```
Details:
    killed: false
    code: 1
    signal: null
    cmd: /Users/iczerwinski/Development/fc/static-content/node_modules/jpegtran-bin/vendor/jpegtran -copy none -optimize -outfile /var/folders/1j/gwvdzjv93vj9z6wvm78s0l2m65zldq/T/cff14f79-cb3a-4e4c-9137-75c55effab90 /var/folders/1j/gwvdzjv93vj9z6wvm78s0l2m65zldq/T/4e080ed1-fbe5-47ef-82f3-838e820a3c66 -progressive
    stdout:
    stderr: /Users/iczerwinski/Development/fc/static-content/node_modules/jpegtran-bin/vendor/jpegtran: only one input file
usage: /Users/iczerwinski/Development/fc/static-content/node_modules/jpegtran-bin/vendor/jpegtran [switches] [inputfile]
Switches (names may be abbreviated):
  -copy none     Copy no extra markers from source file
  -copy comments Copy only comment markers (default)
⋮
```